### PR TITLE
Fix video frame conversion by adding 32-byte alignment to output buffer linesizes

### DIFF
--- a/src/rmedia.c
+++ b/src/rmedia.c
@@ -170,8 +170,8 @@ typedef struct MediaContext
 	// Video stream-related fields
 	struct SwsContext* swsContext;              // Video resampling and scaling context
 	Image videoOutputImage;                     // Image buffer holding the decoded video frame, uploaded to [MediaStream].videoTexture
-	uint8_t *alignedRgbData[4];                 // Pointers to the RGB buffers used for YUV-to-RGB frame conversion
-	int alignedRgbLinesize[4];                  // Linesizes for the RGB buffers used for YUV-to-RGB frame conversion
+	uint8_t *alignedRgbData[4];                 // Pointers to the RGB buffers used for frame conversion
+	int alignedRgbLinesize[4];                  // Linesizes for the RGB buffers used for frame conversion
 
 	// Audio stream-related fields
 	struct SwrContext* swrContext;              // Audio resampling context
@@ -709,7 +709,7 @@ MediaContext* LoadMediaContext(const char* fileName, MediaStreamReader streamRea
 				int allocatedBytes = av_image_alloc(ctx->alignedRgbData, ctx->alignedRgbLinesize, codecCtx->width, codecCtx->height, AV_PIX_FMT_RGB24, 32);
 
 				if (allocatedBytes < 0) {
-					TraceLog(LOG_ERROR, "MEDIA: Cannot allocate memory for the YUV-to-RGB conversion buffer.");
+					TraceLog(LOG_ERROR, "MEDIA: Cannot allocate memory for the frame conversion buffer.");
 					UnloadImage(ctx->videoOutputImage);
 					AVUnloadCodecContext(videoCtx);
 					continue;

--- a/src/rmedia.c
+++ b/src/rmedia.c
@@ -170,6 +170,8 @@ typedef struct MediaContext
 	// Video stream-related fields
 	struct SwsContext* swsContext;              // Video resampling and scaling context
 	Image videoOutputImage;                     // Image buffer holding the decoded video frame, uploaded to [MediaStream].videoTexture
+	uint8_t *alignedRgbData[4];                 // Pointers to the RGB buffers used for YUV-to-RGB frame conversion
+	int alignedRgbLinesize[4];                  // Linesizes for the RGB buffers used for YUV-to-RGB frame conversion
 
 	// Audio stream-related fields
 	struct SwrContext* swrContext;              // Audio resampling context
@@ -702,7 +704,16 @@ MediaContext* LoadMediaContext(const char* fileName, MediaStreamReader streamRea
 				ctx->videoOutputImage.mipmaps = 1;
 				ctx->videoOutputImage.format  = PIXELFORMAT_UNCOMPRESSED_R8G8B8;
 
-				ImageClearBackground(&ctx->videoOutputImage, BLANK),
+				ImageClearBackground(&ctx->videoOutputImage, BLANK);
+
+				int allocatedBytes = av_image_alloc(ctx->alignedRgbData, ctx->alignedRgbLinesize, codecCtx->width, codecCtx->height, AV_PIX_FMT_RGB24, 32);
+
+				if (allocatedBytes < 0) {
+					TraceLog(LOG_ERROR, "MEDIA: Cannot allocate memory for the YUV-to-RGB conversion buffer.");
+					UnloadImage(ctx->videoOutputImage);
+					AVUnloadCodecContext(videoCtx);
+					continue;
+				}
 
 				//-------------------------------------------------------------
 
@@ -890,6 +901,11 @@ void UnloadMediaContext(MediaContext* ctx)
 	{
 		sws_freeContext(ctx->swsContext);
 		ctx->swsContext = NULL;
+	}
+
+	if (ctx->alignedRgbData[0] != NULL)
+	{
+		av_freep(&ctx->alignedRgbData[0]);
 	}
 
 	if (IsImageValid(ctx->videoOutputImage))
@@ -1969,7 +1985,17 @@ int  AVProcessVideoFrame(const MediaStream* media)
 	const int rgbLineSize = codec->width * 3;
 
 	// Convert the frame to RGB
-	sws_scale(ctx->swsContext, (const uint8_t* const*)ctx->avFrame->data, ctx->avFrame->linesize, 0, codec->height, (uint8_t* const*) &ctx->videoOutputImage.data, &rgbLineSize);
+	int ret = sws_scale(ctx->swsContext, (const uint8_t* const*)ctx->avFrame->data, ctx->avFrame->linesize, 0, codec->height, ctx->alignedRgbData, ctx->alignedRgbLinesize);
+	if (ret <= 0) {
+		TraceLog(LOG_ERROR, "MEDIA: Failed to convert frame");
+		return -1;
+	}
+
+	for (int y = 0; y < codec->height; y++) {
+		memcpy((uint8_t*)ctx->videoOutputImage.data + y * rgbLineSize,
+			   ctx->alignedRgbData[0] + y * ctx->alignedRgbLinesize[0],
+			   rgbLineSize);
+	}
 
 	// Update texture with the decoded image data
 	UpdateTexture(media->videoTexture, ctx->videoOutputImage.data);


### PR DESCRIPTION
Closes #12 

# What

- Makes the linesize 32-byte aligned for the output buffer used for video frame conversion
- Memcopies that output into `videoOutputImage.data` (which has no padding bytes between rows)

# Why

`sws_scale` expects aligned linesizes or else certain videos will cause buffer overflows or missing pixels in the output image when writing directly to `videoOutputImage.data`